### PR TITLE
fix(gtdb-parser): respect --use_ncbi_taxonomy in novel-species filter

### DIFF
--- a/gambitdb/GtdbSpreadsheetParser.py
+++ b/gambitdb/GtdbSpreadsheetParser.py
@@ -156,10 +156,14 @@ class GtdbSpreadsheetParser:
         input_spreadsheet_df = input_spreadsheet_df[input_spreadsheet_df['contig_count'] <= self.max_contigs]
         self.stats_contig_count = len(input_spreadsheet_df.index)
 
-        # filter spreadsheet so that if the gtdb_taxonomy column ends with ' sp' followed by digits, then remove the row
+        # filter spreadsheet so that if the species column ends with ' sp' followed by digits, then remove the row
         # These are novel species that GTDB has made up that dont exist in NCBI.
+        # We check 'species' (not 'gtdb_taxonomy') so that --use_ncbi_taxonomy is honoured: once
+        # the species column has been rewritten to NCBI names, placeholder GTDB clades (e.g.
+        # "ECMA0423 sp047199055") will no longer match and genuine NCBI species (e.g. "Shigella
+        # flexneri") won't be incorrectly dropped.
         if not self.include_novel_species:
-            input_spreadsheet_df = input_spreadsheet_df[~input_spreadsheet_df['gtdb_taxonomy'].str.contains(r' sp\d+$')]
+            input_spreadsheet_df = input_spreadsheet_df[~input_spreadsheet_df['species'].str.contains(r' sp\d+$', na=False)]
         self.stats_include_novel_species =  len(input_spreadsheet_df.index)
 
         # if include_derived_samples is False then only include rows with 'none' from ncbi_genome_category


### PR DESCRIPTION
## Summary

The novel-species filter at `GtdbSpreadsheetParser.py:166` was reading the raw `gtdb_taxonomy` column to drop GTDB placeholder species (`sp###`), but `--use_ncbi_taxonomy` and `--ncbi_whitelist` only rewrite the derived `species` column. As a result, genomes whose NCBI name is a real species but whose GTDB name is a placeholder were silently dropped — most visibly losing 797 of 837 *Shigella flexneri* rows and yielding zero *S. flexneri* in the final Escherichia/Shigella database.

This PR points the filter at the `species` column instead. Default builds are unaffected because both columns hold the same value when no rename flag is set. Builds with `--use_ncbi_taxonomy` or `--ncbi_whitelist` now correctly preserve NCBI-named species. Added `na=False` so blank cells in the `species` column don't raise during the regex check.

## Changes

- `gambitdb/GtdbSpreadsheetParser.py:166` — switch column from `gtdb_taxonomy` to `species`; add `na=False`.
- Explanatory comment expanded at lines 159-164 to capture the rationale.

## Test plan

- [x] Existing `GtdbSpreadsheetParser` unit tests pass (2/2 green); 10 unrelated pre-existing failures in the wider suite are present on unmodified main and not caused by this change.
- [x] Verified on a hand-crafted 145-row subset:
  - With `--use_ncbi_taxonomy`: *Shigella flexneri* now appears with `ngenomes=6` (was 0 before fix).
  - Without `--use_ncbi_taxonomy`: genuine `sp\d+$` placeholders still correctly dropped (regression check).
  - No orphan species rows with empty `ngenomes` in `species_taxa.csv` for the affected species.
- [x] Default behaviour unchanged for builds that do not set `--use_ncbi_taxonomy` or `--ncbi_whitelist` — the same rows are dropped because `species` is derived from `gtdb_taxonomy` in that path.

## Out of scope

A secondary issue exists where species whose accessions are removed by the minimum-genomes filter still appear in `species_taxa.csv` with empty `ngenomes` (lines 202-235). This is independent of the column-mismatch bug fixed here and can fire under any flag combination. To be addressed in a follow-up.